### PR TITLE
Added newly required User-Agent, and Accept-Encoding headers.  

### DIFF
--- a/GoToMeeting/GoToMeeting.download.recipe
+++ b/GoToMeeting/GoToMeeting.download.recipe
@@ -28,6 +28,13 @@
                 <string>%url%</string>
                 <key>filename</key>
                 <string>%NAME%.tar.gz</string>
+                <key>request_headers</key>
+                <dict>
+                    <key>User-Agent</key>
+                    <string>Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36</string>
+                    <key>Accept-Encoding</key>
+                    <string>gzip</string>
+                </dict>
             </dict>
         </dict>
         <dict>


### PR DESCRIPTION
Downloader will now 404 without User-Agent, and Accept-Encoding headers.  

I briefly thought about making the User-Agent a parameter, but then decided against it.