### PR TITLE
Changing CodeSignatureVerifier Path

### DIFF
--- a/ScreamingFrogSEO/ScreamingFrogSeo.download.recipe
+++ b/ScreamingFrogSEO/ScreamingFrogSeo.download.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Screaming Frog SEO Spider.app</string>
 				<key>requirement</key>
 				<string>identifier "uk.co.screamingfrog.seo.spider" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = CAHEVC3HZC</string>
 			</dict>


### PR DESCRIPTION
The previous path depended on %NAME% not being changed.  Making the
path static better tolerates changing the NAME.