### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/Amethyst/Amethyst.download.recipe
+++ b/Amethyst/Amethyst.download.recipe
@@ -54,7 +54,7 @@
 				<key>source</key>
 				<string>%found_filename%</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Amethyst.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileMover</string>

--- a/Axure/AxureRP.download.recipe
+++ b/Axure/AxureRP.download.recipe
@@ -38,7 +38,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Axure RP %MAJOR_VERSION%.app</string>
 				<key>requirement</key>
 				<string>identifier "com.axure.AxureRP9" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = HUMW6UU796</string>
 			</dict>

--- a/CodeKit/CodeKit.download.recipe
+++ b/CodeKit/CodeKit.download.recipe
@@ -65,7 +65,7 @@
 				<key>source</key>
 				<string>%found_filename%</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/CodeKit.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileMover</string>

--- a/GoToMeeting/GoToMeeting.download.recipe
+++ b/GoToMeeting/GoToMeeting.download.recipe
@@ -61,7 +61,7 @@
 				<key>source</key>
 				<string>%found_filename%</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/GoToMeeting.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileMover</string>

--- a/TinyGrab/TinyGrab.download.recipe
+++ b/TinyGrab/TinyGrab.download.recipe
@@ -54,7 +54,7 @@
 				<key>source</key>
 				<string>%found_filename%</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/TinyGrab.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileMover</string>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.