### PR TITLE
Basic python3 compatibility

### DIFF
--- a/BalsamiqMockups/BalsamiqMockupsURLProvider.py
+++ b/BalsamiqMockups/BalsamiqMockupsURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2, json
 

--- a/BalsamiqMockups/BalsamiqMockupsURLProvider.py
+++ b/BalsamiqMockups/BalsamiqMockupsURLProvider.py
@@ -58,7 +58,7 @@ class BalsamiqMockupsURLProvider(Processor):
             url = urlopen(base_url).read()
             return json.loads(url[len('jsoncallback('):-2])
 
-        except BaseException as err:
+        except Exception as err:
             raise Exception("Can't read %s: %s" % (base_url, err))
 
     def main(self):

--- a/BalsamiqMockups/BalsamiqMockupsURLProvider.py
+++ b/BalsamiqMockups/BalsamiqMockupsURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 
 from autopkglib import Processor, ProcessorError

--- a/BalsamiqMockups/BalsamiqMockupsURLProvider.py
+++ b/BalsamiqMockups/BalsamiqMockupsURLProvider.py
@@ -16,9 +16,13 @@
 
 from __future__ import absolute_import
 import json
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["BalsamiqMockupsURLProvider"]
 
@@ -50,7 +54,7 @@ class BalsamiqMockupsURLProvider(Processor):
 
     def get_balsamiq_url(self, base_url):
         try:
-            url = urllib2.urlopen(base_url).read()
+            url = urlopen(base_url).read()
             return json.loads(url[len('jsoncallback('):-2])
 
         except BaseException as err:

--- a/BalsamiqMockups/BalsamiqMockupsURLProvider.py
+++ b/BalsamiqMockups/BalsamiqMockupsURLProvider.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
-import urllib2, json
+import json
+import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["BalsamiqMockupsURLProvider"]
 
@@ -51,12 +50,12 @@ class BalsamiqMockupsURLProvider(Processor):
 
     def get_balsamiq_url(self, base_url):
         try:
-        	url = urllib2.urlopen(base_url).read()
-        	return json.loads( url[len('jsoncallback('):-2] )
-        	
+            url = urllib2.urlopen(base_url).read()
+            return json.loads(url[len('jsoncallback('):-2])
+
         except BaseException as err:
-			raise Exception("Can't read %s: %s" % (base_url, err))
-        
+            raise Exception("Can't read %s: %s" % (base_url, err))
+
     def main(self):
         """Find and return a download URL"""
         base_url = self.env.get("base_url", BASE_URL)
@@ -68,5 +67,5 @@ class BalsamiqMockupsURLProvider(Processor):
 
 
 if __name__ == "__main__":
-	processor = BalsamiqMockupsURLProvider()
-	processor.execute_shell()
+    processor = BalsamiqMockupsURLProvider()
+    processor.execute_shell()

--- a/Deluge/DelugeURLProvider.py
+++ b/Deluge/DelugeURLProvider.py
@@ -62,7 +62,7 @@ class DelugeURLProvider(Processor):
                     break
             return BASE_URL+url
 
-        except BaseException as err:
+        except Exception as err:
             raise Exception("Can't read %s: %s" % (base_url, err))
 
     def main(self):

--- a/Deluge/DelugeURLProvider.py
+++ b/Deluge/DelugeURLProvider.py
@@ -55,7 +55,7 @@ class DelugeURLProvider(Processor):
         try:
             version = urlopen(version_url).read()
             page = urlopen(url).read()
-            links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
+            links = re.findall(r"<a.*?\s*href=\"(.*?)\".*?>", page)
             for link in links:
                 if version.rstrip('\n') in link:
                     url = link

--- a/Deluge/DelugeURLProvider.py
+++ b/Deluge/DelugeURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2
 

--- a/Deluge/DelugeURLProvider.py
+++ b/Deluge/DelugeURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import re
 
 from autopkglib import Processor, ProcessorError

--- a/Deluge/DelugeURLProvider.py
+++ b/Deluge/DelugeURLProvider.py
@@ -63,7 +63,7 @@ class DelugeURLProvider(Processor):
             return BASE_URL+url
 
         except BaseException as err:
-        	raise Exception("Can't read %s: %s" % (base_url, err))
+            raise Exception("Can't read %s: %s" % (base_url, err))
 
     def main(self):
         """Find and return a download URL"""

--- a/Deluge/DelugeURLProvider.py
+++ b/Deluge/DelugeURLProvider.py
@@ -16,9 +16,13 @@
 
 from __future__ import absolute_import
 import re
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 
 __all__ = ["DelugeURLProvider"]
@@ -37,7 +41,7 @@ class DelugeURLProvider(Processor):
         "version_url": {
             "required": False,
             "description": "Default is %s" % VERSION_URL,
-        },        
+        },
     }
     output_variables = {
         "url": {
@@ -48,8 +52,8 @@ class DelugeURLProvider(Processor):
 
     def get_Deluge_url(self, url, version_url):
         try:
-            version = urllib2.urlopen(version_url).read()
-            page = urllib2.urlopen(url).read()
+            version = urlopen(version_url).read()
+            page = urlopen(url).read()
             links = re.findall("<a.*?\s*href=\"(.*?)\".*?>", page)
             for link in links:
                 if version.rstrip('\n') in link:
@@ -59,13 +63,13 @@ class DelugeURLProvider(Processor):
 
         except BaseException as err:
         	raise Exception("Can't read %s: %s" % (base_url, err))
-        
+
     def main(self):
         """Find and return a download URL"""
         base_url = self.env.get("base_url", BASE_URL)
         version_url = self.env.get("version_url", VERSION_URL)
         self.env["url"] = self.get_Deluge_url(base_url, version_url)
-        
+
         self.output("Found URL %s" % self.env["url"])
 
 if __name__ == "__main__":

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -53,14 +53,14 @@ class GoToMeetingURLProvider(Processor):
         try:
             jsonData = json.loads(urlopen(base_url).read())
             return jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['macDownloadUrl']
-        except BaseException as err:
+        except Exception as err:
             raise Exception("Can't read %s: %s" % (base_url, err))
 
     def get_g2m_build(self, base_url):
         try:
             jsonData = json.loads(urlopen(base_url).read())
             return str(jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['buildNumber'])
-        except BaseException as err:
+        except Exception as err:
             raise Exception("Can't read %s: %s" % (base_url, err))
 
     def main(self):

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import
 import re
 import urllib2, json
 

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -16,9 +16,13 @@
 
 from __future__ import absolute_import
 import json
-import urllib2
 
 from autopkglib import Processor, ProcessorError
+
+try:
+    from urllib.parse import urlopen  # For Python 3
+except ImportError:
+    from urllib2 import urlopen  # For Python 2
 
 __all__ = ["GoToMeetingURLProvider"]
 
@@ -46,14 +50,14 @@ class GoToMeetingURLProvider(Processor):
 
     def get_g2m_url(self, base_url):
         try:
-            jsonData = json.loads(urllib2.urlopen(base_url).read())
+            jsonData = json.loads(urlopen(base_url).read())
             return jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['macDownloadUrl']
         except BaseException as err:
             raise Exception("Can't read %s: %s" % (base_url, err))
 
     def get_g2m_build(self, base_url):
         try:
-            jsonData = json.loads(urllib2.urlopen(base_url).read())
+            jsonData = json.loads(urlopen(base_url).read())
             return str(jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['buildNumber'])
         except BaseException as err:
             raise Exception("Can't read %s: %s" % (base_url, err))

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import json
 
 from autopkglib import Processor, ProcessorError

--- a/GoToMeeting/GoToMeetingURLProvider.py
+++ b/GoToMeeting/GoToMeetingURLProvider.py
@@ -15,11 +15,10 @@
 # limitations under the License.
 
 from __future__ import absolute_import
-import re
-import urllib2, json
+import json
+import urllib2
 
 from autopkglib import Processor, ProcessorError
-
 
 __all__ = ["GoToMeetingURLProvider"]
 
@@ -47,17 +46,17 @@ class GoToMeetingURLProvider(Processor):
 
     def get_g2m_url(self, base_url):
         try:
-        	jsonData = json.loads(urllib2.urlopen(base_url).read())
-        	return jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['macDownloadUrl']
+            jsonData = json.loads(urllib2.urlopen(base_url).read())
+            return jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['macDownloadUrl']
         except BaseException as err:
-			raise Exception("Can't read %s: %s" % (base_url, err))
+            raise Exception("Can't read %s: %s" % (base_url, err))
 
     def get_g2m_build(self, base_url):
         try:
-        	jsonData = json.loads(urllib2.urlopen(base_url).read())
-        	return str(jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['buildNumber'])
+            jsonData = json.loads(urllib2.urlopen(base_url).read())
+            return str(jsonData['activeBuilds'][len(jsonData['activeBuilds'])-1]['buildNumber'])
         except BaseException as err:
-			raise Exception("Can't read %s: %s" % (base_url, err))
+            raise Exception("Can't read %s: %s" % (base_url, err))
 
     def main(self):
         """Find and return a download URL"""


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later, but this should catch the low-hanging fruit right now.