### PR TITLE
Deprecate TinyGrab recipes

### DIFF
--- a/TinyGrab/TinyGrab.download.recipe
+++ b/TinyGrab/TinyGrab.download.recipe
@@ -18,6 +18,10 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>


### PR DESCRIPTION
The TinyGrab domain is expired, and even before that it was offline for a long time. I think it's safe to say the developer called it quits.

![Screen Shot 2019-09-25 at 4 11 47 PM](https://user-images.githubusercontent.com/7801391/65646274-6c414b00-dfaf-11e9-8c0d-ff640259d753.png)
