### PR TITLE
Switch parent recipe to autopkg/recipes

### DIFF
--- a/AutoPkg-Release/AutoPkg-Release.munki.recipe
+++ b/AutoPkg-Release/AutoPkg-Release.munki.recipe
@@ -38,7 +38,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.rtrouton.download.AutoPkg-Release</string>
+	<string>com.github.autopkg.download.AutoPkg-Release</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
@rtrouton's AutoPkg recipes (for AutoPkg) have been adopted into the main autopkg/recipes repo. This pull request updates the parent recipe.