### PR TITLE
adapt parent recipe for Autopkg-Release Recipe

### DIFF
--- a/AutoPkg-Release/AutoPkg-Release.munki.recipe
+++ b/AutoPkg-Release/AutoPkg-Release.munki.recipe
@@ -38,7 +38,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.rtrouton.download.AutoPkg-Release</string>
+	<string>com.github.autopkg.download.AutoPkg-Release</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
@thenikola The location of the Autopkg-Release Download Recipes changed from the rtrouting-recipes Repo to the recipes Repo of Autopkg. I changed the parent-recipe identifier so that the recipe works again as before.