### PR TITLE
Pre-commit config, identifier changes, and MinimumVersion updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.18.0
+    hooks:
+      - id: check-autopkg-recipes
+        args: ["--recipe-prefix=com.github.thenikola.", "--strict", "--"]
+      - id: forbid-autopkg-overrides
+      - id: forbid-autopkg-trust-info
+  

--- a/Amethyst/Amethyst.download.recipe
+++ b/Amethyst/Amethyst.download.recipe
@@ -14,7 +14,7 @@
 		<string>https://ianyh.com/amethyst/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Amethyst/Amethyst.download.recipe
+++ b/Amethyst/Amethyst.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of Amethyst.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.download.Amethyst</string>
+	<string>com.github.thenikola.download.Amethyst</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/Amethyst/Amethyst.install.recipe
+++ b/Amethyst/Amethyst.install.recipe
@@ -5,13 +5,13 @@
 	<key>Description</key>
 	<string>Downloads the current release version of Amethyst and installs it into applications.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.install.Amethyst</string>
+	<string>com.github.thenikola.install.Amethyst</string>
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.Amethyst</string>
+	<string>com.github.thenikola.download.Amethyst</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Amethyst/Amethyst.munki.recipe
+++ b/Amethyst/Amethyst.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of Amethyst and imports into Munki.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.munki.Amethyst</string>
+	<string>com.github.thenikola.munki.Amethyst</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.3.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.Amethyst</string>
+	<string>com.github.thenikola.download.Amethyst</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Amethyst/AmethystDeprecated.download.recipe
+++ b/Amethyst/AmethystDeprecated.download.recipe
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Stub recipe for forwarding from old identifier to new identifier.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.download.Amethyst</string>
+	<key>Input</key>
+	<dict/>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe's identifier has changed from 'com.github.autopkg.download.Amethyst' to 'com.github.thenikola.download.Amethyst'. Please update your child recipes and overrides accordingly.</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/BalsamiqMockups/BalsamiqMockups.download.recipe
+++ b/BalsamiqMockups/BalsamiqMockups.download.recipe
@@ -12,7 +12,7 @@
 		<string>BalsamiqMockups</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CodeKit/CodeKit.download.recipe
+++ b/CodeKit/CodeKit.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of CodeKit.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.download.CodeKit</string>
+	<string>com.github.thenikola.download.CodeKit</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/CodeKit/CodeKit.download.recipe
+++ b/CodeKit/CodeKit.download.recipe
@@ -14,7 +14,7 @@
 		<string>https://codekitapp.com/api/3/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CodeKit/CodeKit.install.recipe
+++ b/CodeKit/CodeKit.install.recipe
@@ -5,13 +5,13 @@
 	<key>Description</key>
 	<string>Downloads the current release version of CodeKit and installs it into applications.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.install.CodeKit</string>
+	<string>com.github.thenikola.install.CodeKit</string>
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.CodeKit</string>
+	<string>com.github.thenikola.download.CodeKit</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CodeKit/CodeKit.munki.recipe
+++ b/CodeKit/CodeKit.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of CodeKit and imports into Munki.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.munki.CodeKit</string>
+	<string>com.github.thenikola.munki.CodeKit</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 	<key>MinimumVersion</key>
 	<string>0.3.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.CodeKit</string>
+	<string>com.github.thenikola.download.CodeKit</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/CodeKit/CodeKitDeprecated.download.recipe
+++ b/CodeKit/CodeKitDeprecated.download.recipe
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Stub recipe for forwarding from old identifier to new identifier.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.download.CodeKit</string>
+	<key>Input</key>
+	<dict/>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe's identifier has changed from 'com.github.autopkg.download.CodeKit' to 'com.github.thenikola.download.CodeKit'. Please update your child recipes and overrides accordingly.</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Deluge/Deluge.download.recipe
+++ b/Deluge/Deluge.download.recipe
@@ -12,7 +12,7 @@
 		<string>Deluge</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.1</string>
+	<string>0.2.9</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DiskCatalogMaker/DiskCatalogMaker.download.recipe
+++ b/DiskCatalogMaker/DiskCatalogMaker.download.recipe
@@ -14,7 +14,7 @@
 		<string>DiskCatalogMaker</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DiskWave/DiskWave.download.recipe
+++ b/DiskWave/DiskWave.download.recipe
@@ -14,7 +14,7 @@
 		<string>https://diskwave.barthe.ph/sparkle/appcast_64bit.php</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DiskWave/DiskWave.download.recipe
+++ b/DiskWave/DiskWave.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of DiskWave.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.download.DiskWave</string>
+	<string>com.github.thenikola.download.DiskWave</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/DiskWave/DiskWave.install.recipe
+++ b/DiskWave/DiskWave.install.recipe
@@ -5,13 +5,13 @@
 	<key>Description</key>
 	<string>Downloads the current release version of DiskWave and installs it into applications.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.install.DiskWave</string>
+	<string>com.github.thenikola.install.DiskWave</string>
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.DiskWave</string>
+	<string>com.github.thenikola.download.DiskWave</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DiskWave/DiskWave.munki.recipe
+++ b/DiskWave/DiskWave.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of DiskWave and imports into Munki.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.munki.DiskWave</string>
+	<string>com.github.thenikola.munki.DiskWave</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.3.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.DiskWave</string>
+	<string>com.github.thenikola.download.DiskWave</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/DiskWave/DiskWaveDeprecated.download.recipe
+++ b/DiskWave/DiskWaveDeprecated.download.recipe
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Stub recipe for forwarding from old identifier to new identifier.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.download.DiskWave</string>
+	<key>Input</key>
+	<dict/>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe's identifier has changed from 'com.github.autopkg.download.DiskWave' to 'com.github.thenikola.download.DiskWave'. Please update your child recipes and overrides accordingly.</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ScreamingFrogSEO/ScreamingFrogSeo.download.recipe
+++ b/ScreamingFrogSEO/ScreamingFrogSeo.download.recipe
@@ -21,7 +21,7 @@ To download Intel use: (https://download\.screamingfrog\.co\.uk/products/seo-spi
 		<string>https://www.screamingfrog.co.uk</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.1</string>
+	<string>0.3.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TinyGrab/TinyGrab.download.recipe
+++ b/TinyGrab/TinyGrab.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of TinyGrab.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.download.TinyGrab</string>
+	<string>com.github.thenikola.download.TinyGrab</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>

--- a/TinyGrab/TinyGrab.download.recipe
+++ b/TinyGrab/TinyGrab.download.recipe
@@ -14,7 +14,7 @@
 		<string>http://tinygrab.com/appcast/tinygrab-appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TinyGrab/TinyGrab.install.recipe
+++ b/TinyGrab/TinyGrab.install.recipe
@@ -5,13 +5,13 @@
 	<key>Description</key>
 	<string>Downloads the current release version of TinyGrab and installs it into applications.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.install.TinyGrab</string>
+	<string>com.github.thenikola.install.TinyGrab</string>
 	<key>Input</key>
 	<dict/>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.TinyGrab</string>
+	<string>com.github.thenikola.download.TinyGrab</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TinyGrab/TinyGrab.munki.recipe
+++ b/TinyGrab/TinyGrab.munki.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the current release version of TinyGrab and imports into Munki.</string>
 	<key>Identifier</key>
-	<string>com.github.autopkg.munki.TinyGrab</string>
+	<string>com.github.thenikola.munki.TinyGrab</string>
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
@@ -33,7 +33,7 @@
 	<key>MinimumVersion</key>
 	<string>0.3.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.autopkg.download.TinyGrab</string>
+	<string>com.github.thenikola.download.TinyGrab</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/TinyGrab/TinyGrabDeprecated.download.recipe
+++ b/TinyGrab/TinyGrabDeprecated.download.recipe
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Stub recipe for forwarding from old identifier to new identifier.</string>
+	<key>Identifier</key>
+	<string>com.github.autopkg.download.TinyGrab</string>
+	<key>Input</key>
+	<dict/>
+	<key>MinimumVersion</key>
+	<string>0.3.1</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>This recipe's identifier has changed from 'com.github.autopkg.download.TinyGrab' to 'com.github.thenikola.download.TinyGrab'. Please update your child recipes and overrides accordingly.</string>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
### Pre-commit

This pull request adds a [pre-commit](https://pre-commit.com/) configuration to this repository. When pre-commit is installed and active, this feature automatically runs checks before `git commit` operations are executed, and stops the commit from happening if certain errors are detected with the AutoPkg recipe files being added/modified.

For setup instructions and context, see [this post on using pre-commit with AutoPkg recipes](https://www.elliotjordan.com/posts/pre-commit-02-autopkg/).

If you'd like to manually validate all files (outside of `git commit` operations) you can manually do so with this command:

```
% pre-commit run --all-files
Check AutoPkg Recipes....................................................Passed
Forbid AutoPkg Overrides.................................................Passed
Forbid AutoPkg Trust Info................................................Passed
```

### Identifier changes

In order to align with the pre-commit checks mentioned above, the identifiers of several recipes in this repo have been changed as well. **This is a breaking change** for anybody who has already created overrides or child recipes based on these previous identifiers. Upon merge, I will be submitting PRs to update recipes in the AutoPkg org with the new identifiers, however users relying on overrides will need to update the ParentRecipe listed in their override manually, or create a new override.

In order to ease this transition, new "stub" recipes have been added with the old identifiers, which include a deprecation warning directing users to the new identifiers. These recipes should be kept online for at least 30-60 days to give users a chance to see the warnings and make the needed changes.

### MinimumVersion updates

MinimumVersion (of AutoPkg) has been updated in recipes based on processors used in each recipe.

